### PR TITLE
Improve documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,10 @@
 
 ## Common Commands
 
-- TBD
+Use `tinbox --help` to see all available options. A few useful commands:
+
+- `tinbox --to es document.pdf` — translate a PDF to Spanish
+- `tinbox --from zh --to en document.docx` — translate a Word document from Chinese to English
 
 ## Project-Specific Information
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ tinbox --to es document.pdf
 
 ### 🌐 Language Support
 - Flexible source/target language specification using ISO 639-1 codes
-- Common language aliases (e.g., 'en', 'zh', 'es')
+- Common language aliases (e.g., "en", "zh", "es")
 
-6. 📊 **Benchmarking**  
-   - Track overall translation time and token usage/cost
-   - Compare algorithms or model providers side-by-side
+### 📊 Benchmarking
+- Track overall translation time and token usage/cost
+- Compare algorithms or model providers side-by-side
 
 ## 🚀 Getting Started
 
@@ -125,25 +125,28 @@ pip install tinbox[all]
 ### Command-Line Options
 
 #### Core Options
-| Option              | Description                                           | Example                    |
-|--------------------|-------------------------------------------------------|----------------------------|
-| `--from, -f`       | Source language (auto-detect if not specified)        | `--from zh`               |
-| `--to, -t`         | Target language (default: English)                    | `--to es`                 |
-| `--model`          | Model to use for translation                          | `--model gpt-4v`          |
-| `--output, -o`     | Output file (default: print to console)              | `--output translated.txt`  |
+| Option | Description | Example |
+|-------|-------------|---------|
+| `--from, -f` | Source language (auto-detect if not specified) | `--from zh` |
+| `--to, -t` | Target language (default: English) | `--to es` |
+| `--model` | Model to use for translation | `--model gpt-4v` |
+| `--output, -o` | Output file (default: print to console) | `--output translated.txt` |
+
 
 #### Algorithm Options
-| Option              | Description                                           | Default                    |
-|--------------------|-------------------------------------------------------|----------------------------|
-| `--algorithm, -a`  | Translation algorithm (`page` or `sliding-window`)    | `page` for PDF            |
-| `--window-size`    | Size of translation window                            | 2000 tokens               |
-| `--overlap-size`   | Overlap between windows                               | 200 tokens                |
+| Option | Description | Default |
+|-------|-------------|---------|
+| `--algorithm, -a` | Translation algorithm (`page` or `sliding-window`) | `page` for PDF |
+| `--window-size` | Size of translation window | 2000 tokens |
+| `--overlap-size` | Overlap between windows | 200 tokens |
+
 
 #### Output Format Options
-| Option              | Description                                           | Example Output             |
-|--------------------|-------------------------------------------------------|----------------------------|
-| `--format, -F`     | Output format (text, json, markdown)                  | See examples below         |
-| `--benchmark, -b`  | Include performance metrics                           | Translation time, costs    |
+| Option | Description | Example Output |
+|-------|-------------|---------------|
+| `--format, -F` | Output format (text, json, markdown) | See examples below |
+| `--benchmark, -b` | Include performance metrics | Translation time, costs |
+
 
 ### Supported Languages
 


### PR DESCRIPTION
## Summary
- clean up README formatting
- convert benchmarking notes to their own section
- reformat CLI option tables for readability
- expand CLAUDE helper notes

## Testing
- `git status --short`

## Summary by Sourcery

Improve documentation readability by cleaning up README formatting, reorganizing sections, and adding usage examples in CLAUDE.md.

Documentation:
- Clean up README formatting by unifying quote styles, refining headings, and adjusting spacing.
- Promote benchmarking notes to a standalone "Benchmarking" section with bullet points.
- Reformat CLI option tables into concise three-column markdown tables for Core, Algorithm, and Output Format options.
- Expand CLAUDE helper notes with real `tinbox` usage examples and remove placeholder text.